### PR TITLE
Move HTML to templates, serve static CSS

### DIFF
--- a/assets/assets.go
+++ b/assets/assets.go
@@ -1,0 +1,17 @@
+package assets
+
+import "embed"
+
+//go:embed *.gohtml
+var templates embed.FS
+
+//go:embed css/*
+var static embed.FS
+
+func Templates() embed.FS {
+	return templates
+}
+
+func Static() embed.FS {
+	return static
+}

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -1,0 +1,5 @@
+td { padding-right: 15px; }
+.players td.warrior { color: darkred }
+.players td.wizard { color: darkblue }
+.players td.conjurer { color: darkgreen }
+.warning { color: darkorange }

--- a/assets/footer.gohtml
+++ b/assets/footer.gohtml
@@ -1,0 +1,4 @@
+{{define "footer"}}
+</body>
+</html>
+{{end}}

--- a/assets/header.gohtml
+++ b/assets/header.gohtml
@@ -1,0 +1,9 @@
+{{define "header"}}
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <title>OpenNox Server Control</title>
+    <link href="/static/css/style.css" rel="stylesheet">
+</head>
+<body>
+{{end}}

--- a/assets/root.gohtml
+++ b/assets/root.gohtml
@@ -1,0 +1,56 @@
+{{define "root"}}
+{{template "header" .}}
+
+{{$info := .Info}}
+{{$opts := .Opts}}
+
+{{with .Info}}
+<div class="server">
+    <h3>{{ .Name }}</h3>
+    <table summary="server details">
+        <tr><td>Current Map</td><td>{{ .Map }} ({{ .Mode }})</td></tr>
+        <tr><td>Player Count</td><td>{{ .PlayerInfo.Cur }} / {{ .PlayerInfo.Max }}</td></tr>
+    </table><br />
+</div>
+{{end}}
+
+{{with .Info.PlayerInfo.List}}
+<div class="players">
+    <h3>Players:</h3>
+    <table summary="player list">
+        {{range .}}
+        <tr><td class="name">{{.Name}}</td><td class="player {{.Class}}">{{.Class}}</td></tr>
+        {{end}}
+    </table><br />
+</div>
+{{end}}
+
+{{if or .Opts.AllowMapChange .Opts.AllowCommands}}
+    <div class="control">
+        <h3>Control</h3>
+        {{if or .Opts.AllowMapChange .Opts.AllowCommands}}
+            {{if eq .Info.PlayerInfo.Cur 0 | or .Opts.AllowCommands}}
+                <form action="/map/" method="POST">
+                    <label>Change Map</label>
+                    <select name="data">
+                        {{range $m := .Maps}}
+                            <option value="{{ $m }}" {{if eq $info.Map $m}}selected{{end}}>{{ $m }}</option>
+                        {{end}}
+                    </select>
+                    <input type="submit" value="Submit" />
+                </form><br />
+            {{else}}
+                <b class="warning">Map change only allowed when the server is empty.</b><br />
+            {{end}}
+        {{end}}
+        {{if .Opts.AllowCommands}}
+            <form action="/cmd/" method="POST">
+                <label>Command</label>
+                <input type="text" name="data" />
+                <input type="submit" value="Submit" />
+            </form><br />
+        {{end}}
+    </div>
+{{end}}
+{{template "footer" .}}
+{{end}}

--- a/control_panel.go
+++ b/control_panel.go
@@ -2,9 +2,11 @@ package opennoxcontrol
 
 import (
 	"fmt"
+	"html/template"
 	"log"
 	"net/http"
-	"strings"
+
+	"github.com/szhublox/opennoxcontrol/assets"
 )
 
 var defaultMaps = []string{
@@ -30,12 +32,18 @@ func NewControlPanel(game Game, opts *Options) *ControlPanel {
 		// everything defaults to false
 		opts = &Options{}
 	}
+	tmpl, err := template.ParseFS(assets.Templates(), "*.gohtml")
+	if err != nil {
+		panic(err)
+	}
 	cp := &ControlPanel{
 		g:    game,
 		mux:  http.NewServeMux(),
+		tmpl: tmpl,
 		opts: *opts,
 		maps: defaultMaps,
 	}
+	cp.mux.Handle("/static/", http.StripPrefix("/static/", http.FileServer(http.FS(assets.Static()))))
 	cp.mux.HandleFunc("/", cp.rootHandler)
 	if opts.AllowMapChange || opts.AllowCommands {
 		cp.mux.HandleFunc("/map/", cp.mapHandler)
@@ -55,6 +63,7 @@ func NewControlPanel(game Game, opts *Options) *ControlPanel {
 type ControlPanel struct {
 	g    Game
 	mux  *http.ServeMux
+	tmpl *template.Template
 	opts Options
 	maps []string
 }
@@ -63,88 +72,29 @@ func (cp *ControlPanel) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	cp.mux.ServeHTTP(w, r)
 }
 
-func (cp *ControlPanel) refresh_to_root(w http.ResponseWriter) {
+func (cp *ControlPanel) redirectToRoot(w http.ResponseWriter) {
 	fmt.Fprintf(w, "<html><head><meta http-equiv=\"Refresh\""+
 		" content=\"0; url=/\" /></head></html>")
 }
 
-func (cp *ControlPanel) print_players_table(w http.ResponseWriter, info Info) {
-	fmt.Fprintf(w, `<table summary="server details">
-<tr><td>Server Name</td><td>%s</td></tr>
-<tr><td>Current Mode</td><td>%s</td></tr>
-<tr><td>Current Map</td><td>%s</td></tr>
-<tr><td>Player Count</td><td>%d / %d</td></tr>`,
-		info.Name, info.Mode, info.Map, info.PlayerInfo.Cur,
-		info.PlayerInfo.Max)
-
-	if info.PlayerInfo.Cur > 0 {
-		fmt.Fprintf(w, "<tr><td>Players</td><td>")
-		for i := 0; i < info.PlayerInfo.Cur; i++ {
-			fmt.Fprintf(w, "%s the %s",
-				info.PlayerInfo.List[i].Name,
-				info.PlayerInfo.List[i].Class)
-			if i < info.PlayerInfo.Cur-1 {
-				fmt.Fprintf(w, "<br />\n")
-			}
-		}
-		fmt.Fprintf(w, "</td></tr>")
-	}
-
-	fmt.Fprintf(w, "</table>\n")
-}
-
-func (cp *ControlPanel) print_map_form(w http.ResponseWriter, info Info) {
-	fmt.Fprintf(w, "<br />\n")
-	if !cp.opts.AllowCommands {
-		fmt.Fprintf(w,
-			"\n<b>Map change only allowed when "+
-				"the server is empty.</b>")
-	}
-	fmt.Fprintf(w, `<form action="/map/" method="POST">
-<label>Change Map</label>
-<select name="data">`)
-	for _, name := range cp.maps {
-		fmt.Fprintf(w, `<option value="%s"`, name)
-		if strings.EqualFold(name, info.Map) {
-			fmt.Fprintf(w, " selected")
-		}
-		fmt.Fprintf(w, ">%s</option>\n", name)
-	}
-	fmt.Fprintf(w, `</select><input type="submit" value="Submit" /></form>`)
-}
-
-func (cp *ControlPanel) print_command_form(w http.ResponseWriter) {
-	fmt.Fprintf(w, `<br /><form action="/cmd/" method="post">
-<label>Command</label>
-<input type="text" name="data" />
-<input type="submit" value="Submit" />
-</form>
-`)
-}
-
 func (cp *ControlPanel) rootHandler(w http.ResponseWriter, r *http.Request) {
-	var info Info
-
-	fmt.Fprintf(w, "<!DOCTYPE html>\n"+
-		"<html><head><title>OpenNox Server Control</title>\n"+
-		"<style>td { padding-right: 15px; }</style>\n"+
-		"</head>\n"+
-		"<body>\n")
-	defer fmt.Fprintln(w, `</body></html>`)
-
 	info, err := cp.g.GameInfo()
 	if err != nil {
 		log.Println(err)
 		fmt.Fprintf(w, "Couldn't get game data.")
 		return
 	}
-
-	cp.print_players_table(w, info)
-	if cp.opts.AllowMapChange || cp.opts.AllowCommands {
-		cp.print_map_form(w, info)
-	}
-	if cp.opts.AllowCommands {
-		cp.print_command_form(w)
+	err = cp.tmpl.ExecuteTemplate(w, "root", struct {
+		Opts Options
+		Maps []string
+		Info Info
+	}{
+		Opts: cp.opts,
+		Maps: cp.maps,
+		Info: info,
+	})
+	if err != nil {
+		panic(err)
 	}
 }
 
@@ -164,7 +114,7 @@ func (cp *ControlPanel) mapHandler(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	cp.refresh_to_root(w)
+	cp.redirectToRoot(w)
 }
 
 func (cp *ControlPanel) commandHandler(w http.ResponseWriter, r *http.Request) {
@@ -175,5 +125,5 @@ func (cp *ControlPanel) commandHandler(w http.ResponseWriter, r *http.Request) {
 		cp.g.Command(data)
 	}
 
-	cp.refresh_to_root(w)
+	cp.redirectToRoot(w)
 }


### PR DESCRIPTION
- Moves HTML string constants out of Go code into `assets/*.gohtml` (see [text/template](https://pkg.go.dev/text/template) for syntax).
- Moves CSS into a separate file.
- Serve all the above from virtual FS embedded in the binary. 